### PR TITLE
Update settings for ovs_use_veth

### DIFF
--- a/bigswitch-patch-tht.sh
+++ b/bigswitch-patch-tht.sh
@@ -23,7 +23,7 @@ if [ ! -e tht-bigswitch.patch ]; then
     # OpenStack gerrit won't allow direct patch download it seems
     git clone https://github.com/openstack/tripleo-heat-templates || true
     pushd tripleo-heat-templates
-    git fetch https://review.openstack.org/openstack/tripleo-heat-templates refs/changes/42/213142/3 && git format-patch -1 --stdout FETCH_HEAD > ../tht-bigswitch.patch
+    git fetch https://review.openstack.org/openstack/tripleo-heat-templates refs/changes/42/213142/5 && git format-patch -1 --stdout FETCH_HEAD > ../tht-bigswitch.patch
     popd
 fi
 

--- a/dummy-environment.yaml
+++ b/dummy-environment.yaml
@@ -2,8 +2,9 @@ resource_registry:
   OS::TripleO::ControllerExtraConfigPre: /usr/share/openstack-tripleo-heat-templates/puppet/extraconfig/pre_deploy/controller/neutron-bigswitch.yaml
 
 parameters:
-  ExtraConfig:
+  controllerExtraConfig:
     neutron_ovs_use_veth: true
+  NeutronMechanismDrivers: openvswitch,bsn_ml2
 
 parameter_defaults:
   NeutronBigswitchRestproxyServers: 192.0.2.100:8000


### PR DESCRIPTION
Nevermind the patchset update on t-h-t patch, at first i tried a
different solution in patchset 4 and then i reverted it, which created
patchset 5. So patchset 5 is the same as patchset 3, no need to update
local envs. I just want to make sure that it points to the latest, which
will eventually get merged.
